### PR TITLE
Add grid_display and centroid_display

### DIFF
--- a/premake4.lua
+++ b/premake4.lua
@@ -8,6 +8,7 @@ local dependencies = {
     flow_display = {'background_cleaner'},
     frame_generator = {'grey_display'},
     grey_display = {'background_cleaner'},
+    centroid_display = {'background_cleaner'},
     grid_display = {'background_cleaner'},
 }
 setmetatable(dependencies, {__index = function() return {} end})

--- a/premake4.lua
+++ b/premake4.lua
@@ -8,6 +8,7 @@ local dependencies = {
     flow_display = {'background_cleaner'},
     frame_generator = {'grey_display'},
     grey_display = {'background_cleaner'},
+    grid_display = {'background_cleaner'},
 }
 setmetatable(dependencies, {__index = function() return {} end})
 

--- a/source/centroid_display.hpp
+++ b/source/centroid_display.hpp
@@ -1,0 +1,163 @@
+#pragma once
+
+#include <QtQuick/QtQuick>
+#include <array>
+#include <atomic>
+#include <cmath>
+#include <unordered_map>
+
+/// chameleon provides Qt components for event stream display.
+namespace chameleon {
+
+    /// centroid_display displays multiple centroids as circles.
+    class centroid_display : public QQuickPaintedItem {
+        Q_OBJECT
+        Q_PROPERTY(QSize canvas_size READ canvas_size WRITE set_canvas_size)
+        Q_PROPERTY(QColor stroke_color READ stroke_color WRITE set_stroke_color)
+        Q_PROPERTY(qreal stroke_thickness READ stroke_thickness WRITE set_stroke_thickness)
+        Q_PROPERTY(QColor fill_color READ fill_color WRITE set_fill_color)
+        Q_PROPERTY(qreal radius READ radius WRITE set_radius)
+        public:
+        centroid_display(QQuickItem* parent = nullptr) :
+            QQuickPaintedItem(parent),
+            _brush(Qt::transparent, Qt::SolidPattern) {
+            _pen.setColor(Qt::black);
+            _pen.setWidthF(1);
+            _accessing_centroids.clear(std::memory_order_release);
+        }
+        centroid_display(const centroid_display&) = delete;
+        centroid_display(centroid_display&&) = default;
+        centroid_display& operator=(const centroid_display&) = delete;
+        centroid_display& operator=(centroid_display&&) = default;
+        virtual ~centroid_display() {}
+
+        /// set_canvas_size defines the display coordinates.
+        virtual void set_canvas_size(QSize canvas_size) {
+            _canvas_size = canvas_size;
+        }
+
+        /// canvas_size returns the currently used canvas_size.
+        virtual QSize canvas_size() const {
+            return _canvas_size;
+        }
+
+        /// set_stroke_color defines the stroke color for the centroids.
+        virtual void set_stroke_color(QColor color) {
+            _pen.setColor(color);
+        }
+
+        /// stroke_color returns the currently used stroke color.
+        virtual QColor stroke_color() const {
+            return _pen.color();
+        }
+
+        /// set_stroke_thickness defines the stroke thickness for the centroids.
+        virtual void set_stroke_thickness(qreal thickness) {
+            _pen.setWidthF(thickness);
+        }
+
+        /// stroke_thickness returns the currently used stroke thickness.
+        virtual qreal stroke_thickness() const {
+            return _pen.widthF();
+        }
+
+        /// set_fill_color defines the fill color for the centroids.
+        virtual void set_fill_color(QColor color) {
+            _brush.setColor(color);
+        }
+
+        /// fill_color returns the currently used fill color.
+        virtual QColor fill_color() const {
+            return _brush.color();
+        }
+
+        /// set_radius defines the radius level for gaussian representation.
+        virtual void set_radius(qreal radius) {
+            _radius = radius;
+        }
+
+        /// radius returns the currently used radius level.
+        virtual qreal radius() const {
+            return _radius;
+        }
+
+        /// insert displays a centroid, which can be updated later on using its id.
+        template <typename Centroid>
+        void insert(std::size_t id, Centroid centroid) {
+            while (_accessing_centroids.test_and_set(std::memory_order_acquire)) {
+            }
+            auto id_and_centroid_and_took_place = _id_to_centroid.insert(
+                {id, managed_centroid{centroid.x, centroid.y}});
+            if (!id_and_centroid_and_took_place.second) {
+                _accessing_centroids.clear(std::memory_order_release);
+                throw std::logic_error("the given centroid id was already inserted");
+            }
+            _accessing_centroids.clear(std::memory_order_release);
+        }
+
+        /// update modifies the parameters of an existing centroid.
+        template <typename Centroid>
+        void update(std::size_t id, Centroid centroid) {
+            while (_accessing_centroids.test_and_set(std::memory_order_acquire)) {
+            }
+            auto id_and_centroid_candidate = _id_to_centroid.find(id);
+            if (id_and_centroid_candidate == _id_to_centroid.end()) {
+                _accessing_centroids.clear(std::memory_order_release);
+                throw std::logic_error("the given centroid id was not registered with insert");
+            }
+            id_and_centroid_candidate->second.x = centroid.x;
+            id_and_centroid_candidate->second.y = centroid.y;
+            _accessing_centroids.clear(std::memory_order_release);
+        }
+
+        /// erase removes an existing centroid.
+        virtual void erase(std::size_t id) {
+            while (_accessing_centroids.test_and_set(std::memory_order_acquire)) {
+            }
+            if (_id_to_centroid.erase(id) == 0) {
+                _accessing_centroids.clear(std::memory_order_release);
+                throw std::logic_error("the given centroid id was not registered with insert");
+            }
+            _accessing_centroids.clear(std::memory_order_release);
+        }
+
+        /// paint is called by the render thread when drawing is required.
+        virtual void paint(QPainter* painter) override {
+            painter->setPen(_pen);
+            painter->setBrush(_brush);
+            painter->setRenderHint(QPainter::Antialiasing);
+            while (_accessing_centroids.test_and_set(std::memory_order_acquire)) {
+            }
+            for (auto id_and_centroid : _id_to_centroid) {
+                painter->resetTransform();
+                painter->setWindow(0, 0, _canvas_size.width(), _canvas_size.height());
+                painter->translate(id_and_centroid.second.x, _canvas_size.height() - 1 - id_and_centroid.second.y);
+                painter->drawEllipse(QPointF(), _radius, _radius);
+            }
+            _accessing_centroids.clear(std::memory_order_release);
+        }
+
+        public slots:
+        /// trigger_draw requests a window refresh.
+        void trigger_draw() {
+            QQuickPaintedItem::update();
+            if (window()) {
+                window()->update();
+            }
+        }
+
+        protected:
+        /// managed_centroid represents a circular centroid.
+        struct managed_centroid {
+            float x;
+            float y;
+        };
+
+        QSize _canvas_size;
+        QPen _pen;
+        QBrush _brush;
+        qreal _radius;
+        std::unordered_map<std::size_t, managed_centroid> _id_to_centroid;
+        std::atomic_flag _accessing_centroids;
+    };
+}

--- a/source/grid_display.hpp
+++ b/source/grid_display.hpp
@@ -1,0 +1,175 @@
+#pragma once
+
+#include <QtQuick/QtQuick>
+#include <QtQuick/qquickwindow.h>
+#include <atomic>
+#include <cmath>
+#include <memory>
+#include <iostream>
+
+/// chameleon provides Qt components for event stream display.
+namespace chameleon {
+
+    /// grid_display displays a grids as circles.
+    class grid_display : public QQuickPaintedItem {
+        Q_OBJECT
+        Q_PROPERTY(QSize canvas_size READ canvas_size WRITE set_canvas_size)
+        Q_PROPERTY(QColor stroke_color READ stroke_color WRITE set_stroke_color)
+        Q_PROPERTY(qreal offset_x READ offset_x WRITE set_offset_x)
+        Q_PROPERTY(qreal offset_y READ offset_y WRITE set_offset_y)
+        Q_PROPERTY(qreal pitch READ pitch WRITE set_pitch)
+        public:
+        grid_display(QQuickItem* parent = nullptr) :
+            QQuickPaintedItem(parent),
+            _brush(Qt::transparent, Qt::SolidPattern),
+            _stroke_color(Qt::white),
+            _offset_x(0.0f),
+            _offset_y(0.0f),
+            _pitch(20.0f) {
+            _pen.setColor(Qt::black);
+            _pen.setWidthF(1);
+
+            if (_offset_x > _pitch) {
+                _offset_x -= _pitch;
+            }
+            if (_offset_y > _pitch) {
+                _offset_y -= _pitch;
+            }
+        }
+        grid_display(const grid_display&) = delete;
+        grid_display(grid_display&&) = default;
+        grid_display& operator=(const grid_display&) = delete;
+        grid_display& operator=(grid_display&&) = default;
+        virtual ~grid_display() {}
+
+        /// set_canvas_size defines the display coordinates.
+        virtual void set_canvas_size(QSize canvas_size) {
+            _canvas_size = canvas_size;
+            // setImplicitWidth(canvas_size.width());
+            // setImplicitHeight(canvas_size.height());
+        }
+
+        /// canvas_size returns the currently used canvas_size.
+        virtual QSize canvas_size() const {
+            return _canvas_size;
+        }
+
+        /// set_stroke_color defines the stroke color for the grids.
+        virtual void set_stroke_color(QColor stroke_color) {
+            _stroke_color = stroke_color;
+        }
+
+        /// stroke_color returns the currently used stroke color.
+        virtual QColor stroke_color() const {
+            return _stroke_color;
+        }
+
+        /// set_offset_x defines the x offsetfor the grids.
+        virtual void set_offset_x(qreal offset_x) {
+            _offset_x = offset_x;
+        }
+
+        /// offset_x returns the current x offset.
+        virtual qreal offset_x() const {
+            return _offset_x;
+        }
+
+        /// set_offset_y defines the y offsetfor the grids.
+        virtual void set_offset_y(qreal offset_y) {
+            _offset_y = offset_y;
+        }
+
+        /// offset_y returns the current y offset.
+        virtual qreal offset_y() const {
+            return _offset_y;
+        }
+
+        /// set_pitch defines the pitch level for gaussian representation.
+        virtual void set_pitch(qreal pitch) {
+            _pitch = pitch;
+        }
+
+        /// pitch returns the currently used pitch level.
+        virtual qreal pitch() const {
+            return _pitch;
+        }
+
+        /// paint is called by the render thread when drawing is required.
+        virtual void paint(QPainter* painter) override {
+            _pen.setColor(_stroke_color);
+            painter->setPen(_pen);
+            painter->setBrush(_brush);
+            painter->setRenderHint(QPainter::Antialiasing);
+            painter->resetTransform();
+
+            auto clear_area =
+                QRectF(0, 0, width() * window()->devicePixelRatio(), height() * window()->devicePixelRatio());
+            if (clear_area != _clear_area) {
+                _clear_area = std::move(clear_area);
+                if (clear_area.width() * _canvas_size.height() > clear_area.height() * _canvas_size.width()) {
+                    _paint_area.setWidth(clear_area.height() * _canvas_size.width() / _canvas_size.height());
+                    _paint_area.setHeight(clear_area.height());
+                    _paint_area.moveLeft(clear_area.left() + (clear_area.width() - _paint_area.width()) / 2);
+                    _paint_area.moveTop(clear_area.top());
+                } else {
+                    _paint_area.setWidth(clear_area.width());
+                    _paint_area.setHeight(clear_area.width() * _canvas_size.height() / _canvas_size.width());
+                    _paint_area.moveLeft(clear_area.left());
+                    _paint_area.moveTop(clear_area.top() + (clear_area.height() - _paint_area.height()) / 2);
+                }
+            }
+            
+            painter->setWindow(_clear_area.left(), _clear_area.top(),
+                               _clear_area.width(), _clear_area.height());
+
+            const float xscale = _paint_area.width() / _canvas_size.width();
+            const float yscale = _paint_area.height() / _canvas_size.height();
+
+            // draw the boarder
+            painter->drawRect(_paint_area.left() + 1,
+                              _paint_area.top() + 1,
+                              _paint_area.width() - 2,
+                              _paint_area.height() - 2);
+
+            // draw horizontal lines
+            const int x1 = static_cast<int>(_paint_area.left());
+            const int x2 = static_cast<int>(_paint_area.right());
+            for (float y = _offset_y * yscale; y < _paint_area.bottom(); y += _pitch * yscale) {
+                painter->drawLine(x1, y, x2, y);
+            }
+
+            // draw vertical lines
+            const int y1 = static_cast<int>(_paint_area.top());
+            const int y2 = static_cast<int>(_paint_area.bottom());
+            for (float x = _paint_area.left() + _offset_x * xscale; x < _paint_area.right(); x += _pitch * xscale) {
+                painter->drawLine(x, y1, x, y2);
+            }
+        }
+
+        /// paint_area returns the paint area in window coordinates.
+        virtual QRectF paint_area() const {
+            return _paint_area;
+        }
+
+        public slots:
+
+        /// trigger_draw requests a window refresh.
+        void trigger_draw() {
+            QQuickItem::update();
+            if (window()) {
+                window()->update();
+            }
+        }
+
+        protected:
+        QSize _canvas_size;
+        QColor _stroke_color;
+        qreal _offset_x;
+        qreal _offset_y;
+        qreal _pitch;
+        QPen _pen;
+        QBrush _brush;
+        QRectF _clear_area;
+        QRectF _paint_area;
+    };
+}

--- a/test/centroid_display.cpp
+++ b/test/centroid_display.cpp
@@ -1,0 +1,91 @@
+#include "../source/centroid_display.hpp"
+#include "../source/background_cleaner.hpp"
+#include <QtGui/QGuiApplication>
+#include <QtQml/QQmlApplicationEngine>
+#include <atomic>
+#include <chrono>
+#include <random>
+#include <thread>
+
+struct centroid {
+    float x;
+    float y;
+};
+
+int main(int argc, char* argv[]) {
+    QGuiApplication app(argc, argv);
+    qmlRegisterType<chameleon::background_cleaner>("Chameleon", 1, 0, "BackgroundCleaner");
+    qmlRegisterType<chameleon::centroid_display>("Chameleon", 1, 0, "CentroidDisplay");
+    QQmlApplicationEngine application_engine;
+    application_engine.loadData(R""(
+        import QtQuick 2.7
+        import QtQuick.Window 2.2
+        import Chameleon 1.0
+        Window {
+            id: window
+            visible: true
+            width: 320
+            height: 240
+            Timer {
+                interval: 20
+                running: true
+                repeat: true
+                onTriggered: {
+                    centroid_display.trigger_draw();
+                }
+            }
+            BackgroundCleaner {
+                width: window.width
+                height: window.height
+            }
+            CentroidDisplay {
+                id: centroid_display
+                objectName: "centroid_display"
+                canvas_size: "320x240"
+                width: window.width
+                height: window.height
+                stroke_color: "#7eaa5f"
+                stroke_thickness: 3
+                fill_color: "#887eaa5f"
+                radius: 0.5
+            }
+        }
+    )"");
+    auto window = qobject_cast<QQuickWindow*>(application_engine.rootObjects().first());
+    {
+        QSurfaceFormat format;
+        format.setDepthBufferSize(24);
+        format.setStencilBufferSize(8);
+        format.setVersion(3, 3);
+        format.setProfile(QSurfaceFormat::CoreProfile);
+        window->setFormat(format);
+    }
+    auto centroid_display = window->findChild<chameleon::centroid_display*>("centroid_display");
+    std::atomic_bool running(true);
+    std::thread loop([&]() {
+        std::uint64_t t = 0;
+        const auto time_reference = std::chrono::high_resolution_clock::now();
+        for (std::size_t id = 0; id < 3; ++id) {
+            centroid_display->insert(id, centroid{static_cast<float>(102 + 50 * id), 120});
+        }
+        while (running.load(std::memory_order_relaxed)) {
+            for (std::size_t index = 0; index < 10; ++index) {
+                for (std::size_t id = 0; id < 3; ++id) {
+                    centroid_display->update(
+                        id,
+                        centroid{
+                            static_cast<float>(
+                                102 + 50 * id
+                                + 5 * (std::cos(2 * static_cast<float>(M_PI) * (t - id * 1e6f / 3) / 1e6f) + 1.5f)),
+                            120 + 5 * (std::sin(2 * static_cast<float>(M_PI) * (t - id * 1e6f / 3) / 1e6f) + 1.5f)});
+                }
+                t += 2000;
+            }
+            std::this_thread::sleep_until(time_reference + std::chrono::microseconds(t));
+        }
+    });
+    const auto error = app.exec();
+    running.store(false, std::memory_order_relaxed);
+    loop.join();
+    return error;
+}

--- a/test/grid_display.cpp
+++ b/test/grid_display.cpp
@@ -1,0 +1,53 @@
+#include "../source/grid_display.hpp"
+#include "../source/background_cleaner.hpp"
+#include <QtGui/QGuiApplication>
+#include <QtQml/QQmlApplicationEngine>
+#include <atomic>
+#include <chrono>
+#include <random>
+#include <thread>
+
+int main(int argc, char* argv[]) {
+    QGuiApplication app(argc, argv);
+    qmlRegisterType<chameleon::background_cleaner>("Chameleon", 1, 0, "BackgroundCleaner");
+    qmlRegisterType<chameleon::grid_display>("Chameleon", 1, 0, "GridDisplay");
+    QQmlApplicationEngine application_engine;
+    application_engine.loadData(R""(
+        import QtQuick 2.7
+        import QtQuick.Window 2.2
+        import Chameleon 1.0
+        Window {
+            id: window
+            visible: true
+            width: 240
+            height: 180
+            BackgroundCleaner {
+                width: window.width
+                height: window.height
+            }
+            GridDisplay {
+                id: grid_display
+                objectName: "grid_display"
+                canvas_size: "240x180"
+                width: window.width
+                height: window.height
+                stroke_color: "#00275c"
+                offset_x: 5
+                offset_y: 5
+                pitch: 20
+            }
+        }
+    )"");
+    auto window = qobject_cast<QQuickWindow*>(application_engine.rootObjects().first());
+    {
+        QSurfaceFormat format;
+        format.setDepthBufferSize(24);
+        format.setStencilBufferSize(8);
+        format.setVersion(3, 3);
+        format.setProfile(QSurfaceFormat::CoreProfile);
+        window->setFormat(format);
+    }
+    auto grid_display = window->findChild<chameleon::grid_display*>("grid_display");
+    
+    return app.exec();
+}


### PR DESCRIPTION
`grid_display` draws a grid on the background and is useful when paired with the `average_grid` in [Tarsier](https://github.com/neuromorphic-paris/tarsier).

`centroid_display` can be used together with `average_grid` in Tarsier to annotate the averaged position in each grid.